### PR TITLE
Add use_edav parameter to lab data functions

### DIFF
--- a/man/clean_lab_data.Rd
+++ b/man/clean_lab_data.Rd
@@ -10,7 +10,8 @@ clean_lab_data(
   end_date,
   afp_data = NULL,
   ctry_name = NULL,
-  lab_locs_path = NULL
+  lab_locs_path = NULL,
+  use_edav = TRUE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ clean_lab_data(
 \item{ctry_name}{\code{str} or \code{list} Name or a list of countries. Defaults to \code{NULL}.}
 
 \item{lab_locs_path}{\code{str} Location of testing lab locations. Default is \code{NULL}. Will download from EDAV, if necessary.}
+
+\item{use_edav}{\code{logical} Whether to obtain data from EDAV. Defaults to \code{TRUE}.}
 }
 \value{
 \code{tibble} Cleaned lab data.

--- a/man/clean_lab_data_regional.Rd
+++ b/man/clean_lab_data_regional.Rd
@@ -10,7 +10,8 @@ clean_lab_data_regional(
   end_date,
   afp_data = NULL,
   ctry_name = NULL,
-  lab_locs_path = NULL
+  lab_locs_path = NULL,
+  use_edav = TRUE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ clean_lab_data_regional(
 \item{ctry_name}{\code{str} or \code{list} Name or a list of countries. Defaults to \code{NULL}.}
 
 \item{lab_locs_path}{\code{str} Location of testing lab locations. Default is \code{NULL}. Will download from EDAV, if necessary.}
+
+\item{use_edav}{\code{logical} Whether to obtain data from EDAV. Defaults to \code{TRUE}.}
 }
 \value{
 \code{tibble} Cleaned lab data.

--- a/man/get_lab_locs.Rd
+++ b/man/get_lab_locs.Rd
@@ -4,10 +4,12 @@
 \alias{get_lab_locs}
 \title{Table of information regarding testing labs in each country}
 \usage{
-get_lab_locs(path = NULL)
+get_lab_locs(lab_locs_path = NULL, use_edav = TRUE)
 }
 \arguments{
-\item{path}{\code{str} Path to the lab location file. Defaults to \code{NULL}.}
+\item{lab_locs_path}{\code{str} Location of testing lab locations. Default is \code{NULL}. Will download from EDAV, if necessary.}
+
+\item{use_edav}{\code{logical} Whether to obtain data from EDAV. Defaults to \code{TRUE}.}
 }
 \value{
 \code{tibble} A table containing the test lab location information.


### PR DESCRIPTION
Introduces a use_edav argument to clean_lab_data, clean_lab_data_regional, and get_lab_locs, allowing users to control whether lab location data is downloaded from EDAV or loaded from a local file. Updates documentation accordingly and improves error handling for missing lab location files.

Closes #366 

To test:
First download the lab testing locations file (will give this to you directly)
```
# Using edav as default
lab_data <- sirfunctions::edav_io(file_loc = get_constant("CLEANED_LAB_DATA"))
lab_data_cleaned <- clean_lab_data(lab_data, "2024-01-01", "2024-12-31")

# Perform local cleaning
# This should give an error as the lab_locs_path must be specified
lab_data_cleaned <- clean_lab_data(lab_data, "2024-01-01", "2024-12-31", use_edav = F)

# Add the path to the lab_locs data (must be saved locally
lab_data_cleaned <- clean_lab_data(lab_data, "2024-01-01", "2024-12-31", use_edav = F, lab_locs_path = "C:/path/to/lab_locs.csv")
```