### PR TITLE
Add sheet selection to read_excel_from_edav

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -3375,20 +3375,32 @@ explore_edav <- function(path = get_constant("DEFAULT_EDAV_FOLDER"),
 #'
 #'
 #' @param src `str` Path to the Excel file.
+#' @param sheet `int` or `str` Sheet to read. Either a string (the name of a sheet),
+#' or an integer (the position of the sheet).
+#' Ignored if the sheet is specified via range. If neither argument specifies the sheet,
+#' defaults to the first sheet.
 #' @param ... Additional parameters of [readxl::read_excel()].
 #'
 #' @returns `tibble` or `list` A tibble or a list of tibbles containing data from
 #' the Excel file.
 #' @keywords internal
 #'
-read_excel_from_edav <- function(src, ...) {
-  sheets <- readxl::excel_sheets(src)
-  if (length(sheets) > 1) {
-    output <- purrr::map(sheets, \(x) readxl::read_xlsx(path = src, sheet = x,
-                                                        ...))
-    names(output) <- sheets
+read_excel_from_edav <- function(src, sheet = NULL, ...) {
+
+  if (!is.null(sheet)) {
+    # Read the specified sheet
+    output <- readxl::read_excel(path = src, sheet = sheet, ...)
   } else {
-    output <- readxl::read_excel(src)
+    # Read all sheets
+    sheets <- readxl::excel_sheets(src)
+
+    if (endsWith(src, ".xlsx")) {
+      output <- purrr::map(sheets, \(x) readxl::read_xlsx(path = src, sheet = x, ...))
+    } else if (endsWith(src, ".xls")) {
+      output <- purrr::map(sheets, \(x) readxl::read_xls(path = src, sheet = x, ...))
+    }
+
+    names(output) <- sheets
   }
 
   return(output)

--- a/man/read_excel_from_edav.Rd
+++ b/man/read_excel_from_edav.Rd
@@ -4,10 +4,15 @@
 \alias{read_excel_from_edav}
 \title{Reads an Excel file from EDAV to the R environment}
 \usage{
-read_excel_from_edav(src, ...)
+read_excel_from_edav(src, sheet = NULL, ...)
 }
 \arguments{
 \item{src}{\code{str} Path to the Excel file.}
+
+\item{sheet}{\code{int} or \code{str} Sheet to read. Either a string (the name of a sheet),
+or an integer (the position of the sheet).
+Ignored if the sheet is specified via range. If neither argument specifies the sheet,
+defaults to the first sheet.}
 
 \item{...}{Additional parameters of \code{\link[readxl:read_excel]{readxl::read_excel()}}.}
 }


### PR DESCRIPTION
The `read_excel_from_edav()` function now accepts a 'sheet' parameter to allow reading a specific sheet by name or index. Documentation and usage have been updated to reflect this change, and the function now handles both .xlsx and .xls files when reading all sheets. This is an internal function used in `edav_io()`.

To test:
```
# specify sheet using index
check <- edav_io("read", file_loc = "Data/lab/2025-08-29 AFRO Lab Extract (AFP only since 2022).xlsx", sheet = 1)
# specify sheet using string
check <- edav_io("read", file_loc = "Data/lab/2025-08-29 AFRO Lab Extract (AFP only since 2022).xlsx", sheet = "Data Dictionary")
# reads all sheets
check <- edav_io("read", file_loc = "Data/lab/2025-08-29 AFRO Lab Extract (AFP only since 2022).xlsx")
```

Closes #363 